### PR TITLE
Updated settings of favonia/cloudflare-ddns

### DIFF
--- a/templates/cloudflare-ddns/docker-compose.yml.j2
+++ b/templates/cloudflare-ddns/docker-compose.yml.j2
@@ -6,11 +6,8 @@ services:
     # This makes IPv6 easier; see below
     restart: always
     # Restart the updater after reboot
-    cap_add:
-      - SETUID
-        # Capability to change user ID; needed for using PUID
-      - SETGID
-        # Capability to change group ID; needed for using PGID
+    user: "1000:1000"
+    # Run the updater with user/group ID 1000
     cap_drop:
       - all
       # Drop all other capabilities
@@ -20,10 +17,6 @@ services:
       - no-new-privileges:true
         # Another protection to restrict superuser privileges
     environment:
-      - PUID=1000
-        # Run the updater with user ID 1000
-      - PGID=1000
-        # Run the updater with group ID 1000
       - CF_API_TOKEN={{ cloudflare_api_token }}
         # Your Cloudflare API token
       - DOMAINS=adelinofaria.me


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.